### PR TITLE
bulksst: add file allocator interface and adopt SST generation inside import

### DIFF
--- a/pkg/sql/bulkingest/BUILD.bazel
+++ b/pkg/sql/bulkingest/BUILD.bazel
@@ -2,12 +2,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "bulkingest",
-    srcs = ["split.go"],
+    srcs = [
+        "split.go",
+        "split_picker.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/bulkingest",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv",
+        "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/sql/execinfrapb",
+        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )
@@ -16,18 +22,26 @@ go_test(
     name = "bulkingest_test",
     srcs = [
         "main_test.go",
+        "split_picker_test.go",
         "split_test.go",
     ],
     embed = [":bulkingest"],
     deps = [
+        "//pkg/base",
+        "//pkg/keys",
         "//pkg/kv/kvclient/kvtenant",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/execinfrapb",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/encoding",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/randutil",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/bulksst/BUILD.bazel
+++ b/pkg/sql/bulksst/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/bulksst",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/cloud",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",

--- a/pkg/sql/bulksst/BUILD.bazel
+++ b/pkg/sql/bulksst/BUILD.bazel
@@ -2,14 +2,23 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "bulksst",
-    srcs = ["sst_writer.go"],
+    srcs = [
+        "sst_file_allocator.go",
+        "sst_writer.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/bulksst",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/kvserverbase",
+        "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/storage",
+        "//pkg/util/hlc",
         "@com_github_cockroachdb_pebble//objstorage",
+        "@com_github_cockroachdb_pebble//objstorage/objstorageprovider",
+        "@com_github_cockroachdb_pebble//vfs",
     ],
 )
 
@@ -26,13 +35,11 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/storage",
-        "//pkg/storage/fs",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/intsets",
+        "//pkg/util/leaktest",
         "//pkg/util/randutil",
-        "@com_github_cockroachdb_pebble//objstorage",
-        "@com_github_cockroachdb_pebble//objstorage/objstorageprovider",
         "@com_github_cockroachdb_pebble//sstable",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/bulksst/sst_file_allocator.go
+++ b/pkg/sql/bulksst/sst_file_allocator.go
@@ -1,0 +1,60 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package bulksst
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// FileAllocator is used to allocate new files for SSTs ingested via the Writer.
+type FileAllocator interface {
+	// AddFile creates a new file and stores the URI for tracking.
+	AddFile(
+		ctx context.Context, fileIndex int,
+	) (objstorage.Writable, func(), error)
+
+	// GetFileList gets all the files created by this file allocator.
+	GetFileList() []string
+}
+
+// VFSFileAllocator allocates local files for storing SSTs.
+type VFSFileAllocator struct {
+	baseName string
+	fileList []string
+	storage  vfs.FS
+}
+
+// NewVFSFileAllocator creates a new file allocator with baseName and a VFS.
+func NewVFSFileAllocator(baseName string, storage vfs.FS) FileAllocator {
+	return &VFSFileAllocator{
+		baseName: baseName,
+		storage:  storage,
+	}
+}
+
+// AddFile creates a new file and stores the URI for tracking.
+func (f *VFSFileAllocator) AddFile(
+	ctx context.Context, fileIndex int,
+) (objstorage.Writable, func(), error) {
+	fileName := fmt.Sprintf("%s_%d", f.baseName, fileIndex)
+	writer, err := f.storage.Create(fileName, vfs.WriteCategoryUnspecified)
+	if err != nil {
+		return nil, nil, err
+	}
+	remoteWritable := objstorageprovider.NewRemoteWritable(writer)
+	f.fileList = append(f.fileList, fileName)
+	return remoteWritable, func() { writer.Close() }, nil
+}
+
+// GetFileList gets all the files created by this file allocator.
+func (f *VFSFileAllocator) GetFileList() []string {
+	return f.fileList
+}

--- a/pkg/sql/bulksst/sst_writer.go
+++ b/pkg/sql/bulksst/sst_writer.go
@@ -196,6 +196,8 @@ func (s *Writer) CloseWithError(ctx context.Context) error {
 // Close implements kvservebase.BulkAdder.
 func (s *Writer) Close(ctx context.Context) {
 	if err := s.CloseWithError(ctx); err != nil {
+		// TODO(fqazi): Remove panic and find a nicer way to
+		//  surface this error.
 		panic(err)
 	}
 }

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql",
+        "//pkg/sql/bulksst",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",


### PR DESCRIPTION
This patch does the following to the SST writer logic:

1. Adopts the BulkAdder interface so it can be directly dropped into import
2. Refactors the file allocator interface so that there is a VFS and external one, where the latter can be used by import
3. Adopts the new SST writer inside import, if sql.import.distributed_merge is enabled. When this setting is flipped nodelocal is populated with SST's from import for the next phases of this project.