### PR TITLE
bulkmerge: fix distsql flow when there is multiple nodes

### DIFF
--- a/pkg/sql/bulkmerge/merge_coordinator.go
+++ b/pkg/sql/bulkmerge/merge_coordinator.go
@@ -57,13 +57,22 @@ func parseCoordinatorInput(row rowenc.EncDatumRow) (mergeCoordinatorInput, error
 	if len(row) != 3 {
 		return mergeCoordinatorInput{}, errors.Newf("expected 3 columns, got %d", len(row))
 	}
+	if err := row[0].EnsureDecoded(types.Bytes, nil); err != nil {
+		return mergeCoordinatorInput{}, err
+	}
 	sqlInstanceID, ok := row[0].Datum.(*tree.DBytes)
 	if !ok {
 		return mergeCoordinatorInput{}, errors.Newf("expected bytes column for sqlInstanceID, got %s", row[0].Datum.String())
 	}
+	if err := row[1].EnsureDecoded(types.Int4, nil); err != nil {
+		return mergeCoordinatorInput{}, err
+	}
 	taskID, ok := row[1].Datum.(*tree.DInt)
 	if !ok {
 		return mergeCoordinatorInput{}, errors.Newf("expected int4 column for taskID, got %s", row[1].Datum.String())
+	}
+	if err := row[2].EnsureDecoded(types.Bytes, nil); err != nil {
+		return mergeCoordinatorInput{}, err
 	}
 	outputBytes, ok := row[2].Datum.(*tree.DBytes)
 	if !ok {

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -203,7 +203,7 @@ message BulkMergeSpec {
 
 message MergeCoordinatorSpec {
   optional int64 task_count = 1 [(gogoproto.nullable) = false];
-  repeated string worker_sql_instance_ids = 2 [(gogoproto.nullable) = false];
+  repeated bytes worker_sql_instance_ids = 2 [(gogoproto.nullable) = false];
 }
 
 // MergeLoopback is scheduled on the same node as the MergeCoordinator.


### PR DESCRIPTION
There are two bugs fixed by this PR:
1. If a row is passed between nodes, the processor needs to explicitly decode the row.
2. The routing key was getting the type prefix appended twice, so every row was routing to the default processor.