### PR TITLE
sql/import: add support for outputting generated SSTs and start/end keys from import processor

### DIFF
--- a/pkg/sql/bulksst/BUILD.bazel
+++ b/pkg/sql/bulksst/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/execinfrapb",
         "//pkg/storage",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_pebble//objstorage",

--- a/pkg/sql/bulksst/sst_writer_test.go
+++ b/pkg/sql/bulksst/sst_writer_test.go
@@ -62,7 +62,10 @@ func TestBulkSSTWriter(t *testing.T) {
 	for _, fileName := range fileAllocator.GetFileList() {
 		currFileMin := -1
 		currFileMax := -1
-		values := readKeyValuesFromSST(t, fs, fileName)
+		values := readKeyValuesFromSST(t, fs, fileName.Uri)
+		// Validate the span of the SST file.
+		require.Equal(t, fileName.StartKey, string(values[0].Key.Key))
+		require.Equal(t, fileName.EndKey, string(values[len(values)-1].Key.Key))
 		for _, value := range values {
 			keyString := string(value.Key.Key)
 			var num int

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -454,7 +454,7 @@ func TestImportHonorsResumePosition(t *testing.T) {
 					}
 				}()
 
-				_, err := runImport(ctx, flowCtx, spec, progCh, nil /* seqChunkProvider */)
+				_, _, err := runImport(ctx, flowCtx, spec, progCh, nil /* seqChunkProvider */)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -533,7 +533,7 @@ func TestImportHandlesDuplicateKVs(t *testing.T) {
 				}
 			}()
 
-			_, err := runImport(ctx, flowCtx, spec, progCh, nil /* seqChunkProvider */)
+			_, _, err := runImport(ctx, flowCtx, spec, progCh, nil /* seqChunkProvider */)
 			require.True(t, errors.HasType(err, &kvserverbase.DuplicateKeyError{}))
 		})
 	}

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/bulksst"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -50,7 +51,7 @@ func runImport(
 	spec *execinfrapb.ReadImportDataSpec,
 	progCh chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
 	seqChunkProvider *row.SeqChunkProvider,
-) (*kvpb.BulkOpSummary, error) {
+) (*kvpb.BulkOpSummary, []bulksst.FileInfo, error) {
 	// Used to send ingested import rows to the KV layer.
 	kvCh := make(chan row.KVBatch, 10)
 
@@ -60,7 +61,7 @@ func runImport(
 	for _, table := range spec.Tables {
 		cpy := tabledesc.NewBuilder(table.Desc).BuildCreatedMutableTable()
 		if err := typedesc.HydrateTypesInDescriptor(ctx, cpy, importResolver); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		table.Desc = cpy.TableDesc()
 	}
@@ -70,7 +71,7 @@ func runImport(
 	semaCtx := tree.MakeSemaContext(importResolver)
 	conv, err := makeInputConverter(ctx, &semaCtx, spec, evalCtx, kvCh, seqChunkProvider, flowCtx.Cfg.DB.KV())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// This group holds the go routines that are responsible for producing KV batches.
@@ -105,13 +106,14 @@ func runImport(
 	// Ingest the KVs that the producer group emitted to the chan and the row result
 	// at the end is one row containing an encoded BulkOpSummary.
 	var summary *kvpb.BulkOpSummary
+	var files []bulksst.FileInfo
 	group.GoCtx(func(ctx context.Context) error {
-		summary, err = ingestKvs(ctx, flowCtx, spec, progCh, kvCh)
+		summary, files, err = ingestKvs(ctx, flowCtx, spec, progCh, kvCh)
 		return err
 	})
 
 	if err = group.Wait(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var prog execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
@@ -123,9 +125,9 @@ func runImport(
 	}
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, nil, ctx.Err()
 	case progCh <- prog:
-		return summary, nil
+		return summary, files, nil
 	}
 }
 


### PR DESCRIPTION
This patch under the distributed merge setting enables the import processor to output SST files and start / end keys. This should allow this processor to be connected with merge / ingest.