### PR TITLE
bulksst: add support for selecting row samples

### DIFF
--- a/pkg/gen/protobuf.bzl
+++ b/pkg/gen/protobuf.bzl
@@ -53,6 +53,7 @@ PROTOBUF_SRCS = [
     "//pkg/server/status/statuspb:statuspb_go_proto",
     "//pkg/settings:settings_go_proto",
     "//pkg/sql/appstatspb:appstatspb_go_proto",
+    "//pkg/sql/bulksst:bulksst_go_proto",
     "//pkg/sql/catalog/catenumpb:catenumpb_go_proto",
     "//pkg/sql/catalog/catpb:catpb_go_proto",
     "//pkg/sql/catalog/descpb:descpb_go_proto",

--- a/pkg/sql/bulksst/BUILD.bazel
+++ b/pkg/sql/bulksst/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
@@ -6,6 +8,7 @@ go_library(
         "sst_file_allocator.go",
         "sst_writer.go",
     ],
+    embed = [":bulksst_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/bulksst",
     visibility = ["//visibility:public"],
     deps = [
@@ -15,7 +18,6 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
-        "//pkg/sql/execinfrapb",
         "//pkg/storage",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_pebble//objstorage",
@@ -33,6 +35,7 @@ go_test(
     deps = [
         ":bulksst",
         "//pkg/base",
+        "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
@@ -46,4 +49,21 @@ go_test(
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+proto_library(
+    name = "bulksst_proto",
+    srcs = ["sst_info.proto"],
+    strip_import_prefix = "/pkg",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
+)
+
+go_proto_library(
+    name = "bulksst_go_proto",
+    compilers = ["//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_compiler"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/bulksst",
+    proto = ":bulksst_proto",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_gogo_protobuf//gogoproto"],
 )

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -103,7 +103,7 @@ func distImport(
 		useDistributedMerge := UseDistributedMergeForImport.Get(&execCtx.ExecCfg().Settings.SV)
 		outputTypes := []*types.T{types.Bytes, types.Bytes}
 		if useDistributedMerge {
-			outputTypes = []*types.T{types.Bytes, types.Bytes, types.BytesArray}
+			outputTypes = []*types.T{types.Bytes, types.Bytes, types.Bytes}
 		}
 		p.AddNoInputStage(
 			corePlacement,

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -51,7 +51,7 @@ func runImport(
 	spec *execinfrapb.ReadImportDataSpec,
 	progCh chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
 	seqChunkProvider *row.SeqChunkProvider,
-) (*kvpb.BulkOpSummary, []bulksst.FileInfo, error) {
+) (*kvpb.BulkOpSummary, *bulksst.SSTFiles, error) {
 	// Used to send ingested import rows to the KV layer.
 	kvCh := make(chan row.KVBatch, 10)
 
@@ -106,7 +106,7 @@ func runImport(
 	// Ingest the KVs that the producer group emitted to the chan and the row result
 	// at the end is one row containing an encoded BulkOpSummary.
 	var summary *kvpb.BulkOpSummary
-	var files []bulksst.FileInfo
+	var files *bulksst.SSTFiles
 	group.GoCtx(func(ctx context.Context) error {
 		summary, files, err = ingestKvs(ctx, flowCtx, spec, progCh, kvCh)
 		return err


### PR DESCRIPTION
This patch also refactors the SST info to use its own protobuf storing data.